### PR TITLE
Fixed `raise` syntax error

### DIFF
--- a/lib/noid/minter.rb
+++ b/lib/noid/minter.rb
@@ -88,7 +88,7 @@ module Noid
     end
 
     def next_random
-      raise Exception("Exhausted noid sequence pool") if counters.size == 0
+      raise "Exhausted noid sequence pool" if counters.size == 0
       i = @rand.rand(counters.size)
       n = counters[i][:value]
       counters[i][:value] += 1


### PR DESCRIPTION
Not sure if it's really important to use the Exception class, so just pulled that for the default (RuntimeError).