### PR TITLE
Delegate template parsing to Template.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in test.gemspec
 gemspec
 
-gem 'simplecov'
-gem 'simplecov-rcov'
+group :development, :test do
+  gem 'simplecov'
+  gem 'simplecov-rcov'
+  gem 'byebug', require: false
+end

--- a/lib/noid.rb
+++ b/lib/noid.rb
@@ -5,4 +5,7 @@ require 'noid/template'
 module Noid
   XDIGIT = %w(0 1 2 3 4 5 6 7 8 9 b c d f g h j k m n p q r s t v w x z)
   MAX_COUNTERS = 293
+
+  class TemplateError < StandardError
+  end
 end

--- a/lib/noid/minter.rb
+++ b/lib/noid/minter.rb
@@ -34,20 +34,7 @@ module Noid
     # @param [String] id
     # @return bool
     def valid?(id)
-      prefix = @template.prefix.empty? ? '' : id[0..@template.prefix.length - 1]
-      ch = @template.prefix.empty? ? id.split('') : id[@template.prefix.length..-1].split('')
-      check = ch.pop if @template.checkdigit?
-      return false unless prefix == @template.prefix
-
-      return false unless @template.characters.length == ch.length
-      @template.characters.split('').each_with_index do |c, i|
-        return false unless Noid::XDIGIT.include? ch[i]
-        return false if c == 'd' && ch[i] =~ /[^\d]/
-      end
-
-      return false unless check.nil? || check == @template.checkdigit(id[0..-2])
-
-      true
+      template.valid?(id)
     end
 
     ##

--- a/spec/lib/minter_spec.rb
+++ b/spec/lib/minter_spec.rb
@@ -112,6 +112,12 @@ describe Noid::Minter do
       minter2 = described_class.new(template: '.redek')
       expect(minter2.valid?(id)).to eq(true)
     end
+    it 'validates an unlimited sequence with mixed digits' do
+      minter = described_class.new(template: '.zed')
+      1000.times { minter.mint }
+      id = minter.mint
+      expect(minter.valid?(id)).to eq(true)
+    end
   end
 
   describe 'seed' do

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Noid::Template do
+  context 'with a valid template' do
+    let(:template) { '.redek' }
+    it 'initializes without raising' do
+      expect { described_class.new(template) }.not_to raise_error
+    end
+  end
+  context 'with a bogus template' do
+    let(:template) { 'foobar' }
+    it 'raises Noid::TemplateError' do
+      expect { described_class.new(template) }.to raise_error(Noid::TemplateError)
+    end
+  end
+end


### PR DESCRIPTION
Fixes for template validation (see the added spec, which failed before I made any code changes): with template '.zed', the noid '111' *should* be valid, but the code disagreed. Takes the work from #3 (thanks to @dbrower) and rebases it on the latest commit with changes to match current styles.