### PR TITLE
Allow a template to initialize from another template

### DIFF
--- a/lib/noid/template.rb
+++ b/lib/noid/template.rb
@@ -4,9 +4,9 @@ module Noid
 
     VALID_PATTERN = /\A(.*)\.([rsz])([ed]+)(k?)\Z/
 
-    # @param [String] template A Template is a coded string of the form Prefix.Mask that governs how identifiers will be minted.
+    # @param [String, Noid::Template] template a coded string of the form "Prefix.Mask" governing how identifiers will be minted.
     def initialize(template)
-      @template = template
+      @template = template.to_s
       parse!
     end
 

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-
 class OtherTemplate < Noid::Template
 end
 
@@ -10,11 +9,16 @@ describe Noid::Template do
     it 'initializes without raising' do
       expect { described_class.new(template) }.not_to raise_error
     end
+    let(:object) { described_class.new(template) }
+    it 'initializes from Template object' do
+      other = nil
+      expect { other = described_class.new(object) }.not_to raise_error
+      expect(object).to eq(other)
+    end
     it 'stringifies cleanly as the template string' do
-      expect(described_class.new(template).to_s).to eq(template)
+      expect(object.to_s).to eq(template)
     end
     describe 'comparison' do
-      let(:object) { described_class.new(template) }
       it 'unrelated object is not equivalent' do
         expect(object).not_to eq(Array.new)
       end


### PR DESCRIPTION
Basically just calling `to_s` on the incoming arg.
Really allows initialization from anything that converts to a valid
template string.